### PR TITLE
Fixed the solution for Q8 in primitives-challenges

### DIFF
--- a/challenges/primitives-challenges.md
+++ b/challenges/primitives-challenges.md
@@ -206,13 +206,17 @@ function convertTo24HrsFormat(timeText) {
     if (timeTextLower.endsWith('am')) {
         let [hours, mins] = timeTextLower.split(':');
         hours = hours == 12 ? '0' : hours;
-        return hours.padStart(2, 0) + ':' + Number.parseInt(mins);
+        mins = Number.parseInt(mins)
+        mins = mins < 10 ? '0' + mins : mins;
+        return hours.padStart(2, 0) + ':' + mins;
     } 
     // 12 o clock is the special case to be handled both for AM and PM
     else if (timeTextLower.endsWith('pm')) {
         let [hours, mins] = timeTextLower.split(':');
         hours = hours == 12 ? hours : +hours + 12;
-        return hours + ':' + Number.parseInt(mins);
+        mins = Number.parseInt(mins)
+        mins = mins < 10 ? '0' + mins : mins;
+        return hours + ':' + mins;
     }
 }
 ```


### PR DESCRIPTION
## Description:
**Issue:**
The current solution doesn't take into account mins value smaller than 10. For example, if the input is `12:05AM` then the output in the current solution is `12:5` which is incorrect.

**Fix:**
Added a check for mins value less than 10 and in such case concat a `0` before the number.
After fix the output is `12:05`.


Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>