### PR TITLE
Fixing function output and also fn argument typo

### DIFF
--- a/challenges/functions-concepts.md
+++ b/challenges/functions-concepts.md
@@ -673,7 +673,7 @@ const proxy = new Proxy(function () { console.log(arguments); }, {
 
 // driver code
 proxy(1, 2, 3);                 // Proxy apply is invoked on target with context: undefined, arguments: 1,2,3
-proxy.call({}, 1, 2);           // Proxy apply is invoked on target with context: undefined, arguments: 1,2,3
+proxy.call({}, 1, 2);           // Proxy apply is invoked on target with context: [object Object], arguments: 1,2,3
 proxy.apply({}, [5, 10]);       // Proxy apply is invoked on target with context: [object Object], arguments: 5,10
 ```
 

--- a/challenges/functions-concepts.md
+++ b/challenges/functions-concepts.md
@@ -381,16 +381,16 @@ Array and object are used in the programs to contain multiple values
 - Default function parameters allow named parameters to be initialized with default values if no value or undefined is passed
 
 ```js
-function defaultValueFunc(num = 10, num2 = 20, string = "Hello", bool = false, sum = num1 + num2 ){
+function defaultValueFunc(num = 10, num2 = 20, bool = false, sum = num + num2, string = "Hello"){
     console.log(num, string, bool, sum);
 }
 
 // driver code
-defaultValueFunc();                                 //  10, 20, false, 30
-defaultValueFunc(4, 8);                             //  4, 8, false, 12
-defaultValueFunc(10, 4, true);                      //  10, 4, true, 14
-defaultValueFunc(5, 6, false, 11);                  //  5, 6, false, 11
-defaultValueFunc(undefined, undefined, false);      //  10, 20, false, 30
+defaultValueFunc();                                 //  10, 'Hello', false, 30
+defaultValueFunc(4, 8);                             //  4, 'Hello', false, 12
+defaultValueFunc(10, 4, true);                      //  10, 'Hello', true, 14
+defaultValueFunc(5, 6, false, 11);                  //  5, 'Hello', false, 11
+defaultValueFunc(undefined, undefined, false);      //  10, 'Hello', false, 30
 ```
 
 ###### Notes


### PR DESCRIPTION
Found the following two issues in [Q13](https://github.com/sadanandpai/javascript-code-challenges/blob/main/challenges/functions-concepts.md#q13) of functions-concepts.
- argument name was num but sum used num1 + num2. In `strict mode` num1 will not be found ( leading to reference error ) and in non strict mode it will be undefined
- The string argument which is being passed to console.log is being ignored erroneously. Hence moved the string param to end with its default value and modified the output as well.

Found an issue in the `proxy.call` example of [Q20](https://github.com/sadanandpai/javascript-code-challenges/blob/main/challenges/functions-concepts.md#q20) of functions-concepts. as well, where it is typed undefined for the output which ideally should have been an object.