### PR TITLE
Remove arrow function - Q5

### DIFF
--- a/challenges/async-challenges.md
+++ b/challenges/async-challenges.md
@@ -113,7 +113,7 @@ for (var i = num1; i >= num2; i--) {
 var num1 = 10, num2 = 1;
 for (var i = num1; i >= num2; i--) {
     (function (i) {
-        setTimeout(() => console.log(i), (num1 - i) * 1000);
+        setTimeout(console.log, (num1 - i) * 1000,i);
     })(i);
 }
 ```


### PR DESCRIPTION
Q5 states to print numbers from 10 to 1 with a delay of 1 second between each value being printed using setTimeout using **pre** ES6 features only. The second approach used in the solution makes use of the arrow function which was introduced in ES6, since the question requires implementing the solution only using pre-ES6 features, either the arrow function could be replaced with a regular anonymous function `function(){}` or by using `console.log` and passing the value as the third argument, of which I've used the latter approach.