### PR TITLE
The asyncFuncs array seems unnecessary for the nextAsyncFunc function

### DIFF
--- a/web/src/pages/challenges/async.mdx
+++ b/web/src/pages/challenges/async.mdx
@@ -208,7 +208,7 @@ function callbackManager(asyncFuncs) {
   function nextFuncExecutor() {
     const nextAsyncFunc = asyncFuncs.shift();
     if (nextAsyncFunc && typeof nextAsyncFunc === "function") {
-      nextAsyncFunc(nextFuncExecutor, asyncFuncs);
+      nextAsyncFunc(nextFuncExecutor);
     }
   }
   nextFuncExecutor();


### PR DESCRIPTION
The **asyncFunc1**, **asyncFunc2**, and **asyncFunc3** functions, as defined in the code, only accept a single argument, which is the callback function. In this case, the **asyncFuncs** array seems unnecessary for the **nextAsyncFunc** functions, as they don't utilize it directly