### PR TITLE
Correct spelling in concepts/async

### DIFF
--- a/web/src/pages/concepts/async.mdx
+++ b/web/src/pages/concepts/async.mdx
@@ -61,7 +61,7 @@ XHR is used mainly in AJAX programming
 ### 3. Show the working of promise along with resolve & reject code
 
 - The Promise object represents the eventual completion (or failure) of an asynchronous operation and its resulting value
-- Promise returns an object which ramains in pending state until it is resolved or rejected
+- Promise returns an object which remains in pending state until it is resolved or rejected
 - Promise takes a function as an argument called as 'resolver' which can have resolve and reject as parameters
 - Resolve call will resolve the promise and reject will reject the promise (passing data is optional)
 - `then` method on promise object is used to execute the user code after promise settles, which takes functions where 1st one is for success and 2nd for failure


### PR DESCRIPTION
I have corrected the spelling for remains in Concepts > Asynchronous